### PR TITLE
add beforeSend() option, along with tests

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,6 +21,11 @@ var send = function(req, res, hyperjson, options) {
   var body = JSON.stringify(obj);
   res.setHeader("content-type", "application/json");
   res.setHeader("content-length", Buffer.byteLength(body));
+
+  if (_.isFunction(options.beforeSend)) {
+    options.beforeSend(res, obj, body);
+  }
+
   res.end(body);
 };
 

--- a/test/index.js
+++ b/test/index.js
@@ -175,6 +175,39 @@ describe("the middleware", function(){
     });
   });
 
+  describe("options.beforeSend", function () {
+    var res, obj, body;
+
+    function beforeSend (_res, _obj, _body) {
+      res = _res;
+      obj = _obj;
+      body = _body;
+    }
+
+
+    beforeEach(function (done) {
+      app = express();
+      app.use(hyperjson({beforeSend: beforeSend}));
+      app.get("/", function (req, res) {
+        setup(res);
+      });
+      server = http.createServer(app).listen(port, done);
+    });
+
+    afterEach(function (done) {
+      server.close(done);
+    });
+
+    it("is passed the response object, the response body as an object, and the response body as a string", function (done) {
+      request({uri: baseUrl}, function (err, theResponse, theBody) {
+        (res instanceof http.ServerResponse).should.equal(true);
+        theBody.should.equal(body);
+        JSON.parse(theBody).should.eql(obj);
+        done();
+      });
+    });
+  });
+
 
   describe("with express", function(){
     beforeEach(function(done){


### PR DESCRIPTION
This PR allows the use of an optional, synchronous `beforeSend()` function to enable logging and/or metrics on responses immediately before they are sent.

`beforeSend()` should look like this:

``` js
function beforeSend (HttpResponse res, Object body, String stringifiedBody) {
  // do your stuff in here
}
```
